### PR TITLE
Return from getArrayBuffer if object is already an instance of ArrayBuffer

### DIFF
--- a/dist/binary.js
+++ b/dist/binary.js
@@ -203,6 +203,9 @@ function readRecord(blob, messageTypes, startIndex, options, startDate) {
 }
 
 function getArrayBuffer(buffer) {
+  if (buffer instanceof ArrayBuffer) {
+    return buffer;
+  }
   var ab = new ArrayBuffer(buffer.length);
   var view = new Uint8Array(ab);
   for (var i = 0; i < buffer.length; ++i) {

--- a/src/binary.js
+++ b/src/binary.js
@@ -179,6 +179,9 @@ export function readRecord(blob, messageTypes, startIndex, options, startDate) {
 }
 
 export function getArrayBuffer(buffer) {
+  if(buffer instanceof ArrayBuffer) {
+    return buffer;
+  }
   const ab = new ArrayBuffer(buffer.length);
   const view = new Uint8Array(ab);
   for (let i = 0; i < buffer.length; ++i) {


### PR DESCRIPTION
Helps when parsing files in the browser. Can take advantage of `FileReader.readAsArrayBuffer()` and send that directly to the `parse()` function.

https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsArrayBuffer

