### PR TITLE
Add `timer_time` field to `record`

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ Allowed properties :
   - `true`: Continues even if they are errors (**default for now**)
   - `false`: Stops if an error occurs
 - `elapsedRecordField`: Boolean
-  - `true`: Includes a `elapsed_time` field inside each `record` field, containing the elapsed time in seconds since the first record (**default**)
-  - `false`
+  - `true`: Includes `elapsed_time`, containing the elapsed time in seconds since the first record, and `timer_time`, containing the time shown on the device, inside each `record` field
+  - `false` (**default**)
 
 ### easyFit.parse(Buffer _file_, Function _callback_)
 _callback_ receives two arguments, the first as a error String, and the second as Object, result of parsing.

--- a/dist/binary.js
+++ b/dist/binary.js
@@ -148,7 +148,7 @@ function applyOptions(data, field, options) {
     }
 }
 
-function readRecord(blob, messageTypes, startIndex, options, startDate) {
+function readRecord(blob, messageTypes, startIndex, options, startDate, pausedTime) {
     var recordHeader = blob[startIndex];
     var localMessageType = recordHeader & 15;
 
@@ -228,6 +228,7 @@ function readRecord(blob, messageTypes, startIndex, options, startDate) {
 
             if (message.name === 'record' && options.elapsedRecordField) {
                 fields.elapsed_time = (fields.timestamp - startDate) / 1000;
+                fields.timer_time = fields.elapsed_time - pausedTime;
             }
         }
 

--- a/src/binary.js
+++ b/src/binary.js
@@ -117,7 +117,7 @@ function applyOptions(data, field, options) {
     }
 }
 
-export function readRecord(blob, messageTypes, startIndex, options, startDate) {
+export function readRecord(blob, messageTypes, startIndex, options, startDate, pausedTime) {
     const recordHeader = blob[startIndex];
     const localMessageType = (recordHeader & 15);
 
@@ -188,6 +188,7 @@ export function readRecord(blob, messageTypes, startIndex, options, startDate) {
 
             if (message.name === 'record' && options.elapsedRecordField) {
                 fields.elapsed_time = (fields.timestamp - startDate) / 1000;
+                fields.timer_time = fields.elapsed_time - pausedTime;
             }
         }
 


### PR DESCRIPTION
Currently, `records` fields have an `elapsed_time` field that tells us how many seconds have passed since the start of the activity.

This change adds a `timer_time` field to `records`. It's different from `elapsed_time` because `elapsed_time` tells us the total time that has passed since the activity started, including pauses/rests. `timer_time` that tells us the time shown on the device when the record happened.

### Example `record` payloads

#### Before this change

```diff
{
  "timestamp": "2019-03-09T18:36:11.000Z",
  "elapsed_time": 4569,
  "position_lat": 32.75025587528944,
  "position_long": -117.13018745183945,
  "distance": 14.16679,
  "altitude": 0.11679999999999996,
  "speed": 8.686285714285715,
  "heart_rate": 150,
  "cadence": 81,
  "temperature": 15,
  "fractional_cadence": 0
}
```

#### After this change

```json
{
  "timestamp": "2019-03-09T18:36:11.000Z",
  "elapsed_time": 4569,
  "timer_time": 4480,
  "position_lat": 32.75025587528944,
  "position_long": -117.13018745183945,
  "distance": 14.16679,
  "altitude": 0.11679999999999996,
  "speed": 8.686285714285715,
  "heart_rate": 150,
  "cadence": 81,
  "temperature": 15,
  "fractional_cadence": 0
}
```

closes https://github.com/pierremtb/easy-fit/issues/29